### PR TITLE
Group chat sidebar message issue fixed

### DIFF
--- a/src/components/chat/chatsnap/ChatSnap.tsx
+++ b/src/components/chat/chatsnap/ChatSnap.tsx
@@ -150,7 +150,7 @@ const ChatSnap = ({ pfp, username, chatSnapMsg, timestamp, selected, onClick, is
             textAlign="start"
             fontWeight="400"
           >
-            {isGroup ? "Group Invitation Received" : ( message )}
+            {message}
           </SpanV2>
         </ItemHV2>
       </ItemVV2>


### PR DESCRIPTION
Chatsnap is now showing all the possibilities : group created successfully, joined, and message