### PR TITLE
Resolve channel dashboard page breaking on alias chains

### DIFF
--- a/src/components/InitState.tsx
+++ b/src/components/InitState.tsx
@@ -246,7 +246,11 @@ const InitState = () => {
             query: aliasEth,
             env: appConfig.appEnv
           });
-          if(channelDetail) dispatch(setUserChannelDetails(channelDetail[0]));
+          if(channelDetail) {
+            dispatch(setUserChannelDetails(channelDetail[0]));
+            const channelDetailsFromContract = await epnsReadProvider.channels(aliasEth);
+            dispatch(setUserChannelDetails({...channelDetail[0], ...channelDetailsFromContract}));
+          }
           if (!aliasVerified) {
             dispatch(setProcessingState(3));
           } else {


### PR DESCRIPTION
**Cause of Issue:** Channel details were getting fetched from backend on alias chains and it didn't contain expiryTime param, so dashboard was breaking when tried to access it.

**Functionality added:** Added fetching channel details from contract as well for alias chains dashboard.

### Things needed to be check in the QA

- [ ] Channel creation process on Goerli
- [ ] Sending notifications from Goerli
- [ ] Channel creation with alias on Polygon
- [ ] Sending notifications from Polygon
- [ ] Timebound channel creation with alias on Polygon
- [ ] Destroy Channel button should not be visible on Polygon chain once channel is expired (only should be visible on Goerli)