### PR TITLE
#Issue 993 : Fixed re-login issue with Metamask and WalletConnect

### DIFF
--- a/src/AppLogin.tsx
+++ b/src/AppLogin.tsx
@@ -43,7 +43,6 @@ import { swapPropertyOrder } from 'helpers/UtilityHelper';
 // Internal Configs
 import { appConfig } from 'config';
 import GLOBALS, { device } from 'config/Globals';
-import { connect } from 'react-redux';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 
 // define the different type of connectors which we use
@@ -186,7 +185,6 @@ const AppLogin = ({ toggleDarkMode }) => {
           <ItemVV2 alignSelf="stretch" alignItems="flex-start" margin={`0 0 ${GLOBALS.ADJUSTMENTS.MARGIN.VERTICAL} 0`}>
             {Object.keys(web3ConnectorsObj).map((name) => {
               const currentConnector = web3Connectors[name].obj;
-              const [disabled, setDisabled] = useState(false);
               const image = theme.scheme == 'light' ? web3Connectors[name].logolight : web3Connectors[name].logodark;
               const title = web3Connectors[name].title;
 
@@ -200,11 +198,9 @@ const AppLogin = ({ toggleDarkMode }) => {
                   minWidth="140px"
                   alignSelf="stretch"
                   key={name}
-                  onClick={async () => {
+                  onClick={() => {
                     setActivatingConnector(currentConnector);
                     activate(currentConnector);
-                 
-               
                   }}>
                   <ImageV2 src={image} height="40px" width="50px" padding="5px" />
 

--- a/src/AppLogin.tsx
+++ b/src/AppLogin.tsx
@@ -43,6 +43,8 @@ import { swapPropertyOrder } from 'helpers/UtilityHelper';
 // Internal Configs
 import { appConfig } from 'config';
 import GLOBALS, { device } from 'config/Globals';
+import { connect } from 'react-redux';
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 
 // define the different type of connectors which we use
 const web3Connectors = {
@@ -112,6 +114,10 @@ const AppLogin = ({ toggleDarkMode }) => {
     if (activatingConnector && activatingConnector === connector) {
       setActivatingConnector(undefined);
     }
+    if (connector instanceof WalletConnectConnector && walletconnect.walletConnectProvider?.wc?.uri) { 
+      walletconnect.walletConnectProvider = undefined 
+    }
+
   }, [activatingConnector, connector]);
 
   // theme context
@@ -180,13 +186,12 @@ const AppLogin = ({ toggleDarkMode }) => {
           <ItemVV2 alignSelf="stretch" alignItems="flex-start" margin={`0 0 ${GLOBALS.ADJUSTMENTS.MARGIN.VERTICAL} 0`}>
             {Object.keys(web3ConnectorsObj).map((name) => {
               const currentConnector = web3Connectors[name].obj;
-              const disabled = currentConnector === connector;
+              const [disabled, setDisabled] = useState(false);
               const image = theme.scheme == 'light' ? web3Connectors[name].logolight : web3Connectors[name].logodark;
               const title = web3Connectors[name].title;
 
               return (
                 <LoginButton
-                  disabled={disabled}
                   margin="10px"
                   padding="10px"
                   hover={theme.default.hover}
@@ -195,9 +200,11 @@ const AppLogin = ({ toggleDarkMode }) => {
                   minWidth="140px"
                   alignSelf="stretch"
                   key={name}
-                  onClick={() => {
+                  onClick={async () => {
                     setActivatingConnector(currentConnector);
                     activate(currentConnector);
+                 
+               
                   }}>
                   <ImageV2 src={image} height="40px" width="50px" padding="5px" />
 


### PR DESCRIPTION
## What does this PR do?
Fixes #993 
Environment: Prod (app.push.org), Staging (staging.push.org), Dev (dev.push.org)

## Type of change
Bug Fix
Fixed the re-login issue with Metamask and WalletConnect when user rejects a connection request. No need to refresh the DApp.

## How should this be tested?
Open the DApp, click on metamask connect button. Reject the connection request and try again. The pop will open up again.
I'm attaching a screen recording for reference.

https://user-images.githubusercontent.com/75408941/236026712-4610b4fb-5f38-4fb5-bff0-71f8b5f03d43.mp4

