### PR TITLE
Case insensitive case for chat wallet address

### DIFF
--- a/src/contexts/ChatUserContext.tsx
+++ b/src/contexts/ChatUserContext.tsx
@@ -140,7 +140,7 @@ const ChatUserContextProvider = (props) => {
 
     // new user might not have a private key
     if (user && user.encryptedPrivateKey) {
-      if (user.wallets.includes(',') || !user.wallets.includes(caip10)) {
+      if (user.wallets.includes(',') || !user.wallets.toLowerCase().includes(caip10.toLowerCase())) {
         throw Error('Invalid user');
       }
       const _signer = await library.getSigner();


### PR DESCRIPTION
The chat tab does a check to validate the connected wallet matches the expected `caip10` address derived from `user.wallets` field. Currently, the check requires an exact match of the connected wallet address. However, the check should be case insensitive. EVM addresses are valid as lowercase and are often stored in that format, which is the case at Unstoppable Domains.

We noticed an infinite loading scenario when creating a new Push Protocol account with an EVM address as lower case. This is because the wallet signature is never prompted, since an "Invalid user" error is thrown after validation. While we fixed the problem on our side by creating Push Protocol users with the wallet-cased address, this should still be fixed in the Push dapp.

We have some existing internal users who created Push Protocol accounts as lower case EVM addresses. Their accounts will be unusable for chat until this PR is resolved.

### Broken loading chat page in production
Never prompted for wallet signature, due to address validation error. Spins forever, without indication of an error.

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/21039114/236696844-de05c2d5-a67d-41ae-9e81-10998038be6b.png">

### Successfully loading page with case-insensitive checking
Same address, running on local host with fix. User prompted for wallet signature and chat tab loads successfully.

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/21039114/236696697-5a4d59b9-4b39-4bf3-8d35-9dbd1cd886e9.png">

