### PR TITLE
fixed send intent and chat sidebar loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/lab": "^5.0.0-alpha.72",
     "@mui/material": "^5.5.0",
     "@pushprotocol/ledgerlive": "latest",
-    "@pushprotocol/restapi": "^1.2.12",
+    "@pushprotocol/restapi": "latest",
     "@pushprotocol/socket": "latest",
     "@pushprotocol/uiweb": "latest",
     "@reduxjs/toolkit": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/lab": "^5.0.0-alpha.72",
     "@mui/material": "^5.5.0",
     "@pushprotocol/ledgerlive": "latest",
-    "@pushprotocol/restapi": "^1.2.4",
+    "@pushprotocol/restapi": "^1.2.12",
     "@pushprotocol/socket": "latest",
     "@pushprotocol/uiweb": "latest",
     "@reduxjs/toolkit": "^1.7.1",

--- a/src/components/chat/w2wChat/messageFeed/MessageFeed.tsx
+++ b/src/components/chat/w2wChat/messageFeed/MessageFeed.tsx
@@ -76,7 +76,7 @@ const MessageFeed = (props: MessageFeedPropsI): JSX.Element => {
       if (JSON.stringify(inbox) !== JSON.stringify(inboxes)){
         setFeeds(inboxes);
         setInbox(inboxes);
-        intitializeDb<Feeds[]>('Insert', 'Intent', walletToCAIP10({ account }), inboxes, 'did');
+        intitializeDb<Feeds[]>('Insert', 'Inbox', walletToCAIP10({ account }), inboxes, 'did');
         if(checkIfGroup(currentChat)){
        
           if(currentChat && inboxes[selectedChatSnap] && currentChat?.groupInformation?.members?.length !== inboxes[selectedChatSnap]?.groupInformation?.members?.length)

--- a/src/components/chat/w2wChat/messageFeed/MessageFeed.tsx
+++ b/src/components/chat/w2wChat/messageFeed/MessageFeed.tsx
@@ -56,7 +56,6 @@ const MessageFeed = (props: MessageFeedPropsI): JSX.Element => {
     setHasUserBeenSearched(false);
     filteredUserData.length>0 ? setFilteredUserData([]):null;
   }
-
   const getInbox = async (): Promise<Feeds[]> => {
       const getInbox = await intitializeDb<string>('Read', 'Inbox', walletToCAIP10({ account }), '', 'did');
       if (getInbox !== undefined && !inbox.length) {
@@ -74,9 +73,10 @@ const MessageFeed = (props: MessageFeedPropsI): JSX.Element => {
   const fetchInboxApi = async (): Promise<Feeds[]> => {
     try {
       const inboxes:Feeds[] = await fetchInbox(connectedUser);
-      if (JSON.stringify(feeds) !== JSON.stringify(inbox)){
+      if (JSON.stringify(inbox) !== JSON.stringify(inboxes)){
         setFeeds(inboxes);
         setInbox(inboxes);
+        intitializeDb<Feeds[]>('Insert', 'Intent', walletToCAIP10({ account }), inboxes, 'did');
         if(checkIfGroup(currentChat)){
        
           if(currentChat && inboxes[selectedChatSnap] && currentChat?.groupInformation?.members?.length !== inboxes[selectedChatSnap]?.groupInformation?.members?.length)
@@ -159,7 +159,6 @@ const MessageFeed = (props: MessageFeedPropsI): JSX.Element => {
             else {
               feed = await getDefaultFeed({userData:searchedData as User,inbox,intents:receivedIntents});
             }
-            console.log(isNew)
             if(isNew && !feed?.groupInformation?.isPublic)
             {
               messageFeedToast.showMessageToast({

--- a/src/sections/chat/ChatSidebarSection.tsx
+++ b/src/sections/chat/ChatSidebarSection.tsx
@@ -116,6 +116,7 @@ const ChatSidebarSection = ({ showCreateGroupModal, autofilledSearch }) => {
   const fetchIntentApi = async (): Promise<Feeds[]> => {
     const intents = await fetchIntent(connectedUser);
     if (JSON.stringify(intents) != JSON.stringify(receivedIntents)) {
+      intitializeDb<Feeds[]>('Insert', 'Intent', w2wHelper.walletToCAIP10({ account }), intents, 'did');
       setReceivedIntents(intents);
       setLoadingRequests(false);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,7 +4623,7 @@ __metadata:
     "@mui/lab": ^5.0.0-alpha.72
     "@mui/material": ^5.5.0
     "@pushprotocol/ledgerlive": latest
-    "@pushprotocol/restapi": ^1.2.4
+    "@pushprotocol/restapi": ^1.2.12
     "@pushprotocol/socket": latest
     "@pushprotocol/uiweb": latest
     "@reduxjs/toolkit": ^1.7.1
@@ -4823,20 +4823,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pushprotocol/restapi@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@pushprotocol/restapi@npm:1.2.4"
+"@pushprotocol/restapi@npm:^1.2.12":
+  version: 1.2.12
+  resolution: "@pushprotocol/restapi@npm:1.2.12"
   dependencies:
     "@metamask/eth-sig-util": ^5.0.2
     axios: ^0.27.2
     buffer: ^6.0.3
     crypto-js: ^4.1.1
     openpgp: ^5.5.0
+    react: 17.0.2
     tslib: ^2.3.0
     uuid: ^9.0.0
   peerDependencies:
     ethers: ^5.6.8
-  checksum: 9fb1b053d5b40be5b6f0593272f181c052797ec55c1b44b03c6cada59d8f1881a2f9a99982b4784408dfdafc2b04385d80ad102635549a6ccc00d11ecd04cdce
+  checksum: b6c1cd94fd5557607e0c688f7fcfb6f9a26dfe0c36258afd2a8a892fbc4108fa3f8d85299aa92a4ba26b80fb8380e0d414976f34b0b5a9e95c2f3229080c465a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,7 +4623,7 @@ __metadata:
     "@mui/lab": ^5.0.0-alpha.72
     "@mui/material": ^5.5.0
     "@pushprotocol/ledgerlive": latest
-    "@pushprotocol/restapi": ^1.2.12
+    "@pushprotocol/restapi": latest
     "@pushprotocol/socket": latest
     "@pushprotocol/uiweb": latest
     "@reduxjs/toolkit": ^1.7.1
@@ -4823,7 +4823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pushprotocol/restapi@npm:^1.2.12":
+"@pushprotocol/restapi@npm:latest":
   version: 1.2.12
   resolution: "@pushprotocol/restapi@npm:1.2.12"
   dependencies:


### PR DESCRIPTION
Send intent was not working and gave an invalid wallet format issue for profiles created with lower case addresses.
The sidebar was not showing all the chats until we send message to anyone of the chat message and after we accept an intent.